### PR TITLE
Use "docker compose" per default, fall back to "docker-compose"

### DIFF
--- a/main.go
+++ b/main.go
@@ -734,27 +734,32 @@ func getMythicEnvList() []string {
 	return envList
 }
 func runDockerCompose(args []string) error{
-	path, err := exec.LookPath("docker-compose")
+	path, err := exec.LookPath("docker") 
 	if err != nil {
-		// Before failing, try "docker compose" in case docker-compose
-		// is installed as "docker-compose-plugin"
-		path, err = exec.LookPath("docker") 
-		if err != nil {
-			log.Fatalf("[-] docker is not installed or not available in the current PATH variable")
-		}
-		command := exec.Command(path, "compose", "version")
-		err = command.Run()
+		log.Fatalf("[-] docker is not installed or not available in the current PATH variable")
+	}
+
+	// We check if docker-compose is installed as docker plugin
+	command := exec.Command(path, "compose", "version")
+	err = command.Run()
+	if err == nil {
+		// compose is installed as docker plugin, so we use 
+		// the docker executable and prepend "compose" to our args
+		args = append([]string{"compose"}, args...)
+	} else {
+		// We check for the standalone docker-compose binary
+		path, err = exec.LookPath("docker-compose")
 		if err != nil {
 			log.Fatalf("[-] docker-compose is not installed or not available in the current PATH variable")
 		}
-		args = append([]string{"compose"}, args...)
 	}
+
 	exe, err := os.Executable()
 	if err != nil {
 		log.Fatalf("[-] Failed to get path to current executable")
 	}
 	exePath := filepath.Dir(exe)
-	command := exec.Command(path, args...)
+	command = exec.Command(path, args...)
 	command.Dir = exePath
 	command.Env = getMythicEnvList()
 

--- a/main.go
+++ b/main.go
@@ -736,7 +736,18 @@ func getMythicEnvList() []string {
 func runDockerCompose(args []string) error{
 	path, err := exec.LookPath("docker-compose")
 	if err != nil {
-		log.Fatalf("[-] docker-compose is not installed or not available in the current PATH variable")
+		// Before failing, try "docker compose" in case docker-compose
+		// is installed as "docker-compose-plugin"
+		path, err = exec.LookPath("docker") 
+		if err != nil {
+			log.Fatalf("[-] docker is not installed or not available in the current PATH variable")
+		}
+		command := exec.Command(path, "compose", "version")
+		err = command.Run()
+		if err != nil {
+			log.Fatalf("[-] docker-compose is not installed or not available in the current PATH variable")
+		}
+		args = append([]string{"compose"}, args...)
 	}
 	exe, err := os.Executable()
 	if err != nil {


### PR DESCRIPTION
According to the official [documentation](https://docs.docker.com/compose/install/linux/) for docker-compose, it should be installed via the package "docker-compose-plugin" which adds the "docker compose" subcommand to docker as a plugin, instead of the standalone binary form.

This broke ./mythic-cli for me, therefore i wrote this patch.
It is my first time doing golang and this approach seems rather hacky to me,
so if thats a problem i would appreciate it if you can provide me some guidance for a better way!